### PR TITLE
gatt: add missing bit definitions

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "arm-none-eabi-gdb -q"
+#runner = "arm-none-eabi-gdb -q"
+runner = "probe-run --chip stm32wb55rgvx"
 
 rustflags = [
   "-C", "link-arg=-Tlink.x",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ ms = []
 
 [dependencies]
 stm32wb-hal = { version = "0.1.1" , features=["xG-package"]}
-nb = "0.1.1"
+nb = "1.0"
 bluetooth-hci = "0.1"
-bitflags = "1.0"
-bbqueue = "0.4.8"
+bitflags = "1.3"
+bbqueue = "0.4"
 
 [dependencies.embedded-hal]
 version = "0.2.3"
@@ -32,16 +32,16 @@ default-features = false
 
 # For examples
 [dev-dependencies]
-cortex-m = "0.6.2"
+cortex-m = "0.6.7"
+cortex-m-rt = "0.6.7"
 stm32wb-pac = "0.2"
-as-slice = "0.1"
-bit_field = "0.10.0"
-heapless = "0.5.3"
-nb = "0.1"
+as-slice = "0.2"
+bit_field = "0.10"
+heapless = "0.7.5"
+nb = "1.0"
 cortex-m-rtic = "0.5"
-rtt-target = { version = "0.2.0", features = ["cortex-m"]}
-panic-rtt-target = { version = "0.1.0", features = ["cortex-m"] }
-cortex-m-rt = "0.6.6"
+rtt-target = { version = "0.3.1", features = ["cortex-m"]}
+panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
 usb-device = "0.2"
 usbd-serial = "0.1.0"
 
@@ -53,3 +53,7 @@ codegen-units = 1
 codegen-units = 1
 debug = true
 lto = true
+
+[patch.crates-io]
+# The Tiwalun demos required this.
+bluetooth-hci = { git = "https://github.com/danielgallagher0/bluetooth-hci", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["ms"]
 ms = []
 
 [dependencies]
-stm32wb-hal = { version = "0.1.1" }
+stm32wb-hal = { version = "0.1.1" , features=["xG-package"]}
 nb = "0.1.1"
 bluetooth-hci = "0.1"
 bitflags = "1.0"
@@ -38,11 +38,9 @@ as-slice = "0.1"
 bit_field = "0.10.0"
 heapless = "0.5.3"
 nb = "0.1"
-cortex-m-rtfm = "0.5"
-panic-halt = "0.2.0"
-panic-reset = "0.1.0"
-panic-semihosting = "0.5.0"
-cortex-m-semihosting = { version = "0.3.5", features = ["jlink-quirks"] }
+cortex-m-rtic = "0.5"
+rtt-target = { version = "0.2.0", features = ["cortex-m"]}
+panic-rtt-target = { version = "0.1.0", features = ["cortex-m"] }
 cortex-m-rt = "0.6.6"
 usb-device = "0.2"
 usbd-serial = "0.1.0"

--- a/examples/ble.rs
+++ b/examples/ble.rs
@@ -1,0 +1,308 @@
+use bbqueue::{consts::U514, BBBuffer, ConstBBBuffer};
+use bluetooth_hci::{
+    event::command::{CommandComplete, ReturnParameters},
+    host::uart::{Hci as UartHci, Packet},
+    Event, Status,
+};
+use core::fmt::Debug;
+use nb::block;
+use rtt_target::rprintln;
+use stm32wb55::{
+    event::{command::GattCharacteristicDescriptor, AttributeHandle, Stm32Wb5xEvent},
+    gatt::{
+        AccessPermission, AddCharacteristicParameters, AddDescriptorParameters,
+        AddServiceParameters, CharacteristicEvent, CharacteristicHandle, CharacteristicPermission,
+        CharacteristicProperty, Commands as GattCommands, DescriptorHandle, DescriptorPermission,
+        EncryptionKeySize, ServiceHandle, ServiceType, UpdateCharacteristicValueParameters, Uuid,
+    },
+    RadioCoprocessor,
+};
+use stm32wb_hal::{
+    interrupt,
+    ipcc::Ipcc,
+    tl_mbox::{shci::ShciBleInitCmdParam, TlMbox},
+};
+
+pub type RadioCopro = RadioCoprocessor<'static, U514>;
+
+static BB: BBBuffer<U514> = BBBuffer(ConstBBBuffer::new());
+
+static mut RADIO_COPROCESSOR: Option<RadioCopro> = None;
+
+pub fn setup_coprocessor(config: ShciBleInitCmdParam, ipcc: Ipcc, mbox: TlMbox) {
+    let (producer, consumer) = BB.try_split().unwrap();
+    let rc = RadioCoprocessor::new(producer, consumer, mbox, ipcc, config);
+
+    unsafe {
+        RADIO_COPROCESSOR = Some(rc);
+    }
+}
+
+#[derive(Debug)]
+pub struct Service {
+    handle: ServiceHandle,
+
+    max_num_attributes: u8,
+}
+
+impl Service {
+    pub fn new(
+        service_type: ServiceType,
+        uuid: Uuid,
+        max_attribute_records: u8,
+    ) -> Result<Self, ()> {
+        rprintln!("Adding service {:x?}", uuid);
+
+        let protocol_handle = perform_command(|rc: &mut RadioCopro| {
+            let service = AddServiceParameters {
+                service_type,
+                uuid,
+                max_attribute_records,
+            };
+            rc.add_service(&service)
+        })?;
+
+        if let ReturnParameters::Vendor(
+            stm32wb55::event::command::ReturnParameters::GattAddService(
+                stm32wb55::event::command::GattService {
+                    service_handle,
+                    status,
+                },
+            ),
+        ) = protocol_handle
+        {
+            rprintln!("Handle {:?}, status {:?}", service_handle, status);
+            check_status(&status).expect("Failed to add service");
+            Ok(Service {
+                handle: service_handle,
+                max_num_attributes: max_attribute_records,
+            })
+        } else {
+            //writeln!(serial, "Unexpected response to init_gap command");
+            Err(())
+        }
+    }
+
+    pub fn add_characteristic(
+        &self,
+        uuid: &Uuid,
+        properties: CharacteristicProperty,
+        event_mask: CharacteristicEvent,
+        value_len: usize,
+        is_variable: bool,
+    ) -> Result<Characteristic, ()> {
+        rprintln!("Adding characteristic {:x?}", uuid);
+        rprintln!(" Properties: {:?}", properties);
+
+        let response = perform_command(|rc: &mut RadioCopro| {
+            rc.add_characteristic(&AddCharacteristicParameters {
+                service_handle: self.handle,
+                characteristic_uuid: *uuid,
+                characteristic_properties: properties,
+                characteristic_value_len: value_len,
+
+                is_variable,
+
+                // Initially hardcoded
+                gatt_event_mask: event_mask,
+                encryption_key_size: EncryptionKeySize::with_value(16).unwrap(),
+                fw_version_before_v72: false,
+                security_permissions: CharacteristicPermission::empty(),
+            })
+        })?;
+
+        if let ReturnParameters::Vendor(
+            stm32wb55::event::command::ReturnParameters::GattAddCharacteristic(
+                stm32wb55::event::command::GattCharacteristic {
+                    characteristic_handle,
+                    status,
+                },
+            ),
+        ) = response
+        {
+            check_status(&status).expect("Failed to add characteristic");
+            rprintln!("Handle (declaration): {:?}", characteristic_handle);
+            rprintln!("Handle (value): {:?}", characteristic_handle.0 + 1);
+
+            // If the notify or indicate properties are set,
+            // a CCCD (Client characteristic configuration descriptor) is allocated as well.
+            if properties
+                .intersects(CharacteristicProperty::NOTIFY | CharacteristicProperty::INDICATE)
+            {
+                rprintln!(
+                    "Client characteristic configuration: Handle={}",
+                    characteristic_handle.0 + 1,
+                );
+            }
+
+            Ok(Characteristic {
+                service: self.handle,
+                characteristic: characteristic_handle,
+                max_len: value_len,
+            })
+        } else {
+            Err(())
+        }
+    }
+
+    /// Check if this service contains the given handle.
+    ///
+    /// The check is done based on the maximum number of handles
+    /// reserved for this service, as given in the `Service::new`
+    /// function. A value of `true` does not guarantee that
+    /// the given handle has actually been created, however the
+    /// given handle cannot exist in any other service.
+    pub fn contains_handle(&self, handle: AttributeHandle) -> bool {
+        let value = handle.0;
+
+        let service_handle = self.handle.0;
+
+        service_handle <= value && value < (service_handle + self.max_num_attributes as u16)
+    }
+}
+
+#[derive(Debug)]
+pub struct Characteristic {
+    pub service: ServiceHandle,
+    pub characteristic: CharacteristicHandle,
+
+    pub max_len: usize,
+}
+
+impl Characteristic {
+    pub fn set_value(&self, value: &[u8]) -> Result<(), ()> {
+        if value.len() > self.max_len {
+            return Err(());
+        }
+
+        let response = perform_command(|rc: &mut RadioCopro| {
+            rc.update_characteristic_value(&UpdateCharacteristicValueParameters {
+                service_handle: self.service,
+                characteristic_handle: self.characteristic,
+                offset: 0,
+                value,
+            })
+            .map_err(|_| nb::Error::Other(()))
+        })?;
+
+        if let ReturnParameters::Vendor(
+            stm32wb55::event::command::ReturnParameters::GattUpdateCharacteristicValue(status),
+        ) = response
+        {
+            rprintln!("Update value: {:?}", status);
+            check_status(&status)?;
+        } else {
+            // Unexpected response;
+            rprintln!("Unexpected reponse to UpdateValue: {:?}", response);
+        };
+
+        Ok(())
+    }
+
+    pub fn add_descriptor(&self, uuid: Uuid, length: usize) -> Result<DescriptorHandle, ()> {
+        let dummy_slice = [0u8; 10];
+
+        assert!(length <= 10, "Hack: Not implemented for length > 10");
+
+        let descriptor = perform_command(|rc: &mut RadioCopro| {
+            rc.add_characteristic_descriptor(&mut AddDescriptorParameters {
+                service_handle: self.service,
+                characteristic_handle: self.characteristic,
+                descriptor_uuid: uuid,
+                descriptor_value_max_len: length,
+                descriptor_value: &dummy_slice[..length],
+                security_permissions: DescriptorPermission::empty(),
+                access_permissions: AccessPermission::READ,
+                gatt_event_mask: CharacteristicEvent::ATTRIBUTE_WRITE
+                    | CharacteristicEvent::CONFIRM_READ,
+                encryption_key_size: EncryptionKeySize::with_value(16).unwrap(),
+                is_variable: false,
+            })
+            .map_err(|_| nb::Error::Other(()))
+        })?;
+
+        let descriptor_handle = match descriptor {
+            ReturnParameters::Vendor(
+                stm32wb55::event::command::ReturnParameters::GattAddCharacteristicDescriptor(
+                    GattCharacteristicDescriptor {
+                        status,
+                        descriptor_handle,
+                    },
+                ),
+            ) => {
+                check_status(&status)?;
+                descriptor_handle
+            }
+            _ => {
+                rprintln!("Unexpected response to init_gap command");
+                return Err(());
+            }
+        };
+
+        rprintln!("Descriptor {:?} - {:?}", uuid, descriptor_handle);
+
+        Ok(descriptor_handle)
+    }
+}
+
+fn check_status<S: Debug>(status: &Status<S>) -> Result<(), ()> {
+    if let Status::Success = status {
+        Ok(())
+    } else {
+        rprintln!("Status not succesfull: {:?}", status);
+        Err(())
+    }
+}
+
+pub fn perform_command(
+    command: impl Fn(&mut RadioCopro) -> nb::Result<(), ()>,
+) -> Result<ReturnParameters<Stm32Wb5xEvent>, ()> {
+    // Send command (blocking)
+    block!(cortex_m::interrupt::free(|_| {
+        let rc = unsafe { RADIO_COPROCESSOR.as_mut().unwrap() };
+        command(rc)
+    }))?;
+
+    let response = block!(receive_event()).unwrap(); // .map_err(|_| Err(()))?;
+
+    if let Packet::Event(Event::CommandComplete(CommandComplete {
+        return_params,
+        num_hci_command_packets: _,
+    })) = response
+    {
+        Ok(return_params)
+    } else {
+        Err(())
+    }
+}
+
+pub fn receive_event() -> nb::Result<
+    Packet<Stm32Wb5xEvent>,
+    bluetooth_hci::host::uart::Error<(), stm32wb55::event::Stm32Wb5xError>,
+> {
+    cortex_m::interrupt::free(|_| {
+        let rc = unsafe { RADIO_COPROCESSOR.as_mut().unwrap() };
+        if rc.process_events() {
+            rc.read()
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    })
+}
+
+// Handle IPCC_C1_RX_IT interrupt
+#[interrupt]
+fn IPCC_C1_RX_IT() {
+    unsafe {
+        RADIO_COPROCESSOR.as_mut().unwrap().handle_ipcc_rx();
+    }
+}
+
+// Handle IPCC_C1_TX_IT interrupt
+#[interrupt]
+fn IPCC_C1_TX_IT() {
+    // TODO: Critical section?
+    unsafe {
+        RADIO_COPROCESSOR.as_mut().unwrap().handle_ipcc_tx();
+    }
+}

--- a/examples/eddystone_alt.rs
+++ b/examples/eddystone_alt.rs
@@ -1,0 +1,358 @@
+//! BLE Eddystone URL beacon example.
+#![no_main]
+#![no_std]
+#![allow(non_snake_case)]
+
+use panic_rtt_target as _;
+// use panic_halt as _;
+use rtt_target::{rprintln, rtt_init_print};
+
+extern crate stm32wb_hal as hal;
+
+use core::{convert::TryFrom, future::Pending, time::Duration};
+
+use cortex_m_rt::{entry, exception};
+use nb::block;
+
+use hal::{
+    flash::FlashExt,
+    prelude::*,
+    rcc::{
+        ApbDivider, Config, HDivider, HseDivider, PllConfig, PllSrc, RfWakeupClock, RtcClkSrc,
+        StopWakeupClock, SysClkSrc,
+    },
+    tl_mbox::{lhci::LhciC1DeviceInformationCcrp, shci::ShciBleInitCmdParam, TlMbox},
+};
+
+use bluetooth_hci::{
+    event::{command::ReturnParameters, Event},
+    host::{uart::Packet, AdvertisingFilterPolicy, EncryptionKey, Hci, OwnAddressType},
+    BdAddr,
+};
+
+use ble::{perform_command, receive_event, setup_coprocessor, Characteristic, RadioCopro};
+use stm32wb55::{
+    event::{AttReadPermitRequest, AttributeHandle, GattAttributeModified, Stm32Wb5xEvent},
+    gap::{
+        AdvertisingDataType, AdvertisingType, AuthenticationRequirements, Commands as GapCommands,
+        DiscoverableParameters, LocalName, OutOfBandAuthentication, Pin, Role,
+    },
+    gatt::{CharacteristicProperty, Commands as GattCommads, UpdateCharacteristicValueParameters},
+    hal::{Commands as HalCommands, ConfigData, PowerLevel},
+};
+
+mod ble;
+
+/// Advertisement interval in milliseconds.
+const ADV_INTERVAL_MS: u64 = 250;
+
+const BT_NAME: &[u8] = b"BEACON";
+const BLE_GAP_DEVICE_NAME_LENGTH: u8 = BT_NAME.len() as u8;
+
+// Setup Eddystone beacon to advertise this URL:
+// https://www.rust-lang.org
+const EDDYSTONE_URL_PREFIX: EddystoneUrlScheme = EddystoneUrlScheme::Https;
+const EDDYSTONE_URL: &[u8] = b"www.rust-lang.com";
+const CALIBRATED_TX_POWER_AT_0_M: u8 = -22_i8 as u8;
+
+// Need to be at least 257 bytes to hold biggest possible HCI BLE event + header
+const BLE_DATA_BUF_SIZE: usize = 257 * 2;
+//const BLE_GAP_DEVICE_NAME_LENGTH: u8 = 7;
+
+#[entry]
+fn entry() -> ! {
+    //rtt_init_print!(BlockIfFull, 4096);
+    rtt_init_print!(NoBlockSkip, 4096);
+    run();
+
+    loop {
+        continue;
+    }
+}
+
+fn run() {
+    let dp = hal::device::Peripherals::take().unwrap();
+    let mut rcc = dp.RCC.constrain();
+    rcc.set_stop_wakeup_clock(StopWakeupClock::HSI16);
+
+    // Fastest clock configuration.
+    // * External low-speed crystal is used (LSE)
+    // * 32 MHz HSE with PLL
+    // * 64 MHz CPU1, 32 MHz CPU2
+    // * 64 MHz for APB1, APB2
+    // * HSI as a clock source after wake-up from low-power mode
+    let clock_config = Config::new(SysClkSrc::Pll(PllSrc::Hse(HseDivider::NotDivided)))
+        .with_lse()
+        .cpu1_hdiv(HDivider::NotDivided)
+        .cpu2_hdiv(HDivider::Div2)
+        .apb1_div(ApbDivider::NotDivided)
+        .apb2_div(ApbDivider::NotDivided)
+        .pll_cfg(PllConfig {
+            m: 2,
+            n: 12,
+            r: 3,
+            q: Some(4),
+            p: Some(3),
+        })
+        .rtc_src(RtcClkSrc::Lse)
+        .rf_wkp_sel(RfWakeupClock::Lse);
+
+    let mut rcc = rcc.apply_clock_config(clock_config, &mut dp.FLASH.constrain().acr);
+
+    rprintln!("Boot");
+
+    // RTC is required for proper operation of BLE stack
+    let _rtc = hal::rtc::Rtc::rtc(dp.RTC, &mut rcc);
+
+    let mut ipcc = dp.IPCC.constrain();
+    let mbox = TlMbox::tl_init(&mut rcc, &mut ipcc);
+
+    let config = ShciBleInitCmdParam {
+        p_ble_buffer_address: 0,
+        ble_buffer_size: 0,
+        num_attr_record: 100,
+        num_attr_serv: 10,
+        attr_value_arr_size: 3500, //2788,
+        num_of_links: 8,
+        extended_packet_length_enable: 1,
+        pr_write_list_size: 0x3A,
+        mb_lock_count: 0x79,
+        att_mtu: 312,
+        slave_sca: 500,
+        master_sca: 0,
+        ls_source: 1,
+        max_conn_event_length: 0xFFFFFFFF,
+        hs_startup_time: 0x148,
+        viterbi_enable: 1,
+        ll_only: 0,
+        hw_version: 0,
+    };
+
+    setup_coprocessor(config, ipcc, mbox);
+
+    // enable interrupts -> interrupts are enabled in Ipcc::init(), which is called TlMbox::tl_init
+
+    // Boot CPU2
+    hal::pwr::set_cpu2(true);
+
+    let ready_event = block!(receive_event());
+
+    rprintln!("Received packet: {:?}", ready_event);
+
+    rprintln!("Resetting processor...");
+
+    let reset_response = perform_command(|rc| rc.reset()).expect("Failed to reset processor");
+
+    rprintln!("Received packet: {:?}", reset_response);
+
+    init_gap_and_gatt().expect("Failed to initialize GAP and GATT");
+
+    rprintln!("Succesfully initialized GAP and GATT");
+
+    init_eddystone().expect("Failed to initialize eddystone setup");
+
+    rprintln!("Succesfully initialized eddystone");
+
+    loop {
+        let response = block!(receive_event());
+
+        rprintln!("Received event: {:x?}", response);
+
+        if let Ok(Packet::Event(event)) = response {
+            match event {
+                other => rprintln!("ignoring event {:?}", other),
+            }
+        }
+    }
+}
+
+#[exception]
+fn DefaultHandler(irqn: i16) -> ! {
+    panic!("Unhandled IRQ: {}", irqn);
+}
+
+fn get_bd_addr() -> BdAddr {
+    let mut bytes = [0u8; 6];
+
+    let lhci_info = LhciC1DeviceInformationCcrp::new();
+    bytes[0] = (lhci_info.uid64 & 0xff) as u8;
+    bytes[1] = ((lhci_info.uid64 >> 8) & 0xff) as u8;
+    bytes[2] = ((lhci_info.uid64 >> 16) & 0xff) as u8;
+    bytes[3] = lhci_info.device_type_id;
+    bytes[4] = (lhci_info.st_company_id & 0xff) as u8;
+    bytes[5] = (lhci_info.st_company_id >> 8 & 0xff) as u8;
+
+    BdAddr(bytes)
+}
+
+fn init_gap_and_gatt() -> Result<(), ()> {
+    let response = perform_command(|rc: &mut RadioCopro| {
+        rc.write_config_data(&ConfigData::public_address(get_bd_addr()).build())
+    })?;
+
+    rprintln!("Response to write_config_data: {:?}", response);
+
+    perform_command(|rc| {
+        rc.write_config_data(&ConfigData::random_address(get_random_addr()).build())
+    })?;
+
+    perform_command(|rc| rc.write_config_data(&ConfigData::identity_root(&get_irk()).build()))?;
+
+    perform_command(|rc| rc.write_config_data(&ConfigData::encryption_root(&get_erk()).build()))?;
+
+    perform_command(|rc| rc.set_tx_power_level(PowerLevel::ZerodBm))?;
+
+    perform_command(|rc| rc.init_gatt())?;
+
+    let return_params =
+        perform_command(|rc| rc.init_gap(Role::PERIPHERAL, false, BLE_GAP_DEVICE_NAME_LENGTH))?;
+
+    let (service_handle, dev_name_handle, appearence_handle) = if let ReturnParameters::Vendor(
+        stm32wb55::event::command::ReturnParameters::GapInit(stm32wb55::event::command::GapInit {
+            service_handle,
+            dev_name_handle,
+            appearance_handle,
+            ..
+        }),
+    ) = return_params
+    {
+        (service_handle, dev_name_handle, appearance_handle)
+    } else {
+        rprintln!("Unexpected response to init_gap command");
+        return Err(());
+    };
+
+    perform_command(|rc| {
+        rc.update_characteristic_value(&UpdateCharacteristicValueParameters {
+            service_handle,
+            characteristic_handle: dev_name_handle,
+            offset: 0,
+            value: BT_NAME,
+        })
+        .map_err(|_| nb::Error::Other(()))
+    })?;
+
+    let appearance_characteristic = Characteristic {
+        service: service_handle,
+        characteristic: appearence_handle,
+        max_len: 4,
+    };
+
+    appearance_characteristic.set_value(&[0x80, 0x00])?;
+    return Ok(());
+}
+
+#[derive(Copy, Clone)]
+#[allow(dead_code)]
+enum EddystoneUrlScheme {
+    HttpWww = 0x00,
+    HttpsWww = 0x01,
+    Http = 0x02,
+    Https = 0x03,
+}
+
+fn init_eddystone() -> Result<(), ()> {
+    perform_command(|rc: &mut RadioCopro| {
+        rc.le_set_scan_response_data(&[])
+            .map_err(|_| nb::Error::Other(()))
+    })?;
+
+    // non-connectable mode...
+    perform_command(|rc| {
+        rc.set_discoverable(&DISCOVERY_PARAMS)
+            .map_err(|_| nb::Error::Other(()))
+    })?;
+
+    // remove some advertisements
+    perform_command(|rc| rc.delete_ad_type(AdvertisingDataType::TxPowerLevel))?;
+    perform_command(|rc| rc.delete_ad_type(AdvertisingDataType::PeripheralConnectionInterval))?;
+
+    perform_command(|rc| {
+        let url_len = EDDYSTONE_URL.len();
+
+        let mut service_data = [0u8; 24];
+        service_data[0] = 6 + url_len as u8;
+        service_data[1] = AdvertisingDataType::ServiceData as u8;
+
+        // 16-bit Eddystone UUID
+        service_data[2] = 0xAA;
+        service_data[3] = 0xFE;
+
+        service_data[4] = 0x10; // URL frame type
+        service_data[5] = CALIBRATED_TX_POWER_AT_0_M;
+        service_data[6] = EDDYSTONE_URL_PREFIX as u8;
+
+        service_data[7..(7 + url_len)].copy_from_slice(EDDYSTONE_URL);
+
+        rc.update_advertising_data(&service_data[..])
+            .map_err(|_| nb::Error::Other(()))
+    })?;
+
+    perform_command(|rc| {
+        let service_uuid_list = [
+            3_u8,
+            AdvertisingDataType::UuidCompleteList16 as u8,
+            0xAA,
+            0xFE,
+        ];
+
+        rc.update_advertising_data(&service_uuid_list[..])
+            .map_err(|_| nb::Error::Other(()))
+    })?;
+
+    perform_command(|rc| {
+        let flags = [
+            2,
+            AdvertisingDataType::Flags as u8,
+            (0x02 | 0x04) as u8, // BLE general discoverable, without BR/EDR support.
+        ];
+
+        rc.update_advertising_data(&flags[..])
+            .map_err(|_| nb::Error::Other(()))
+    })?;
+
+    return Ok(());
+}
+
+fn get_random_addr() -> BdAddr {
+    let mut bytes = [0u8; 6];
+
+    let lhci_info = LhciC1DeviceInformationCcrp::new();
+    bytes[0] = (lhci_info.uid64 & 0xff) as u8;
+    bytes[1] = ((lhci_info.uid64 >> 8) & 0xff) as u8;
+    bytes[2] = ((lhci_info.uid64 >> 16) & 0xff) as u8;
+    bytes[3] = 0;
+    bytes[4] = 0x6E;
+    bytes[5] = 0xED;
+
+    BdAddr(bytes)
+}
+
+const BLE_CFG_IRK: [u8; 16] = [
+    0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+];
+const BLE_CFG_ERK: [u8; 16] = [
+    0xfe, 0xdc, 0xba, 0x09, 0x87, 0x65, 0x43, 0x21, 0xfe, 0xdc, 0xba, 0x09, 0x87, 0x65, 0x43, 0x21,
+];
+
+fn get_irk() -> EncryptionKey {
+    EncryptionKey(BLE_CFG_IRK)
+}
+
+fn get_erk() -> EncryptionKey {
+    EncryptionKey(BLE_CFG_ERK)
+}
+
+const DISCOVERY_PARAMS: DiscoverableParameters = DiscoverableParameters {
+    advertising_type: AdvertisingType::NonConnectableUndirected,
+    advertising_interval: Some((
+        Duration::from_millis(ADV_INTERVAL_MS),
+        Duration::from_millis(ADV_INTERVAL_MS),
+    )),
+    address_type: OwnAddressType::Public,
+    filter_policy: AdvertisingFilterPolicy::AllowConnectionAndScan,
+    // Local name should be empty for the device to be recognized as an Eddystone beacon
+    local_name: None,
+    advertising_data: &[],
+    conn_interval: (None, None),
+};

--- a/examples/eddystone_alt.rs
+++ b/examples/eddystone_alt.rs
@@ -51,8 +51,8 @@ const BLE_GAP_DEVICE_NAME_LENGTH: u8 = BT_NAME.len() as u8;
 
 // Setup Eddystone beacon to advertise this URL:
 // https://www.rust-lang.org
-const EDDYSTONE_URL_PREFIX: EddystoneUrlScheme = EddystoneUrlScheme::Https;
-const EDDYSTONE_URL: &[u8] = b"www.rust-lang.com";
+const EDDYSTONE_URL_PREFIX: EddystoneUrlScheme = EddystoneUrlScheme::HttpsWww;
+const EDDYSTONE_URL: &[u8] = b"rust-lang.com";
 const CALIBRATED_TX_POWER_AT_0_M: u8 = -22_i8 as u8;
 
 // Need to be at least 257 bytes to hold biggest possible HCI BLE event + header

--- a/examples/ibeacon_alt.rs
+++ b/examples/ibeacon_alt.rs
@@ -1,0 +1,360 @@
+//! BLE Apple iBeacon example.
+#![no_main]
+#![no_std]
+#![allow(non_snake_case)]
+
+use panic_rtt_target as _;
+// use panic_halt as _;
+use rtt_target::{rprintln, rtt_init_print};
+
+extern crate stm32wb_hal as hal;
+
+use core::{convert::TryFrom, future::Pending, time::Duration};
+
+use cortex_m_rt::{entry, exception};
+use nb::block;
+
+use hal::{
+    flash::FlashExt,
+    prelude::*,
+    rcc::{
+        ApbDivider, Config, HDivider, HseDivider, PllConfig, PllSrc, RfWakeupClock, RtcClkSrc,
+        StopWakeupClock, SysClkSrc,
+    },
+    tl_mbox::{lhci::LhciC1DeviceInformationCcrp, shci::ShciBleInitCmdParam, TlMbox},
+};
+
+use bluetooth_hci::{
+    event::{command::ReturnParameters, Event},
+    host::{uart::Packet, AdvertisingFilterPolicy, EncryptionKey, Hci, OwnAddressType},
+    BdAddr,
+};
+
+use ble::{perform_command, receive_event, setup_coprocessor, Characteristic, RadioCopro};
+use stm32wb55::{
+    event::{AttReadPermitRequest, AttributeHandle, GattAttributeModified, Stm32Wb5xEvent},
+    gap::{
+        AdvertisingDataType, AdvertisingType, AuthenticationRequirements, Commands as GapCommands,
+        DiscoverableParameters, LocalName, OutOfBandAuthentication, Pin, Role,
+    },
+    gatt::{CharacteristicProperty, Commands as GattCommads, UpdateCharacteristicValueParameters},
+    hal::{Commands as HalCommands, ConfigData, PowerLevel},
+};
+
+mod ble;
+
+// Apple iBeacon UUID specific for your application.
+// You can use https://yupana-engineering.com/online-uuid-to-c-array-converter to convert
+// UUID string into byte array
+const IBEACON_UUID: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+const IBEACON_MAJOR: [u8; 2] = [0, 1]; // Two-byte iBeacon major
+const IBEACON_MINOR: [u8; 2] = [0, 1]; // Two-byte iBeacon minor
+
+/// Advertisement interval in milliseconds.
+const ADV_INTERVAL_MS: u64 = 250;
+
+/// TX power at 0 m range. Used for range approximation.
+const CALIBRATED_TX_POWER_AT_0_M: u8 = 193;
+
+// Required to be recognised as iBeacon
+const BLE_BEACON_NAME: &[u8] = b"BEACON";
+
+
+#[entry]
+fn entry() -> ! {
+    //rtt_init_print!(BlockIfFull, 4096);
+    rtt_init_print!(NoBlockSkip, 4096);
+    run();
+
+    loop {
+        continue;
+    }
+}
+
+fn run() {
+    let dp = hal::device::Peripherals::take().unwrap();
+    let mut rcc = dp.RCC.constrain();
+    rcc.set_stop_wakeup_clock(StopWakeupClock::HSI16);
+
+    // Fastest clock configuration.
+    // * External low-speed crystal is used (LSE)
+    // * 32 MHz HSE with PLL
+    // * 64 MHz CPU1, 32 MHz CPU2
+    // * 64 MHz for APB1, APB2
+    // * HSI as a clock source after wake-up from low-power mode
+    let clock_config = Config::new(SysClkSrc::Pll(PllSrc::Hse(HseDivider::NotDivided)))
+        .with_lse()
+        .cpu1_hdiv(HDivider::NotDivided)
+        .cpu2_hdiv(HDivider::Div2)
+        .apb1_div(ApbDivider::NotDivided)
+        .apb2_div(ApbDivider::NotDivided)
+        .pll_cfg(PllConfig {
+            m: 2,
+            n: 12,
+            r: 3,
+            q: Some(4),
+            p: Some(3),
+        })
+        .rtc_src(RtcClkSrc::Lse)
+        .rf_wkp_sel(RfWakeupClock::Lse);
+
+    let mut rcc = rcc.apply_clock_config(clock_config, &mut dp.FLASH.constrain().acr);
+
+    rprintln!("Boot");
+
+    // RTC is required for proper operation of BLE stack
+    let _rtc = hal::rtc::Rtc::rtc(dp.RTC, &mut rcc);
+
+    let mut ipcc = dp.IPCC.constrain();
+    let mbox = TlMbox::tl_init(&mut rcc, &mut ipcc);
+
+    let config = ShciBleInitCmdParam {
+        p_ble_buffer_address: 0,
+        ble_buffer_size: 0,
+        num_attr_record: 100,
+        num_attr_serv: 10,
+        attr_value_arr_size: 1344,
+        num_of_links: 8,
+        extended_packet_length_enable: 1,
+        pr_write_list_size: 0x3A,
+        mb_lock_count: 0x79,
+        att_mtu: 156,
+        slave_sca: 500,
+        master_sca: 0,
+        ls_source: 1,
+        max_conn_event_length: 0xFFFFFFFF,
+        hs_startup_time: 0x148,
+        viterbi_enable: 1,
+        ll_only: 0,
+        hw_version: 0,
+    };
+
+    setup_coprocessor(config, ipcc, mbox);
+
+    // enable interrupts -> interrupts are enabled in Ipcc::init(), which is called TlMbox::tl_init
+
+    // Boot CPU2
+    hal::pwr::set_cpu2(true);
+
+    let ready_event = block!(receive_event());
+
+    rprintln!("Received packet: {:?}", ready_event);
+
+    rprintln!("Resetting processor...");
+
+    let reset_response = perform_command(|rc| rc.reset()).expect("Failed to reset processor");
+
+    rprintln!("Received packet: {:?}", reset_response);
+
+    init_gap_and_gatt().expect("Failed to initialize GAP and GATT");
+
+    rprintln!("Succesfully initialized GAP and GATT");
+
+    init_ibeacon().expect("Failed to initialize iBeacon");
+
+    rprintln!("Succesfully initialized iBeacon");
+
+    loop {
+        let response = block!(receive_event());
+
+        rprintln!("Received event: {:x?}", response);
+
+        if let Ok(Packet::Event(event)) = response {
+            match event {
+                other => rprintln!("ignoring event {:?}", other),
+            }
+        }
+    }
+}
+
+#[exception]
+unsafe fn DefaultHandler(irqn: i16) -> ! {
+    panic!("Unhandled IRQ: {}", irqn);
+}
+
+fn get_bd_addr() -> BdAddr {
+    let mut bytes = [0u8; 6];
+
+    let lhci_info = LhciC1DeviceInformationCcrp::new();
+    bytes[0] = (lhci_info.uid64 & 0xff) as u8;
+    bytes[1] = ((lhci_info.uid64 >> 8) & 0xff) as u8;
+    bytes[2] = ((lhci_info.uid64 >> 16) & 0xff) as u8;
+    bytes[3] = lhci_info.device_type_id;
+    bytes[4] = (lhci_info.st_company_id & 0xff) as u8;
+    bytes[5] = (lhci_info.st_company_id >> 8 & 0xff) as u8;
+
+    BdAddr(bytes)
+}
+
+fn init_gap_and_gatt() -> Result<(), ()> {
+    let response = perform_command(|rc: &mut RadioCopro| {
+        rc.write_config_data(&ConfigData::public_address(get_bd_addr()).build())
+    })?;
+
+    rprintln!("Response to write_config_data: {:?}", response);
+
+    perform_command(|rc| {
+        rc.write_config_data(&ConfigData::random_address(get_random_addr()).build())
+    })?;
+
+    perform_command(|rc| rc.write_config_data(&ConfigData::identity_root(&get_irk()).build()))?;
+
+    perform_command(|rc| rc.write_config_data(&ConfigData::encryption_root(&get_erk()).build()))?;
+
+    perform_command(|rc| rc.set_tx_power_level(PowerLevel::ZerodBm))?;
+
+    perform_command(|rc| rc.init_gatt())?;
+
+    let return_params =
+        perform_command(|rc| rc.init_gap(Role::PERIPHERAL, false,
+                                         BLE_BEACON_NAME.len() as u8))?;
+
+    let (service_handle, dev_name_handle, appearence_handle) = if let ReturnParameters::Vendor(
+        stm32wb55::event::command::ReturnParameters::GapInit(stm32wb55::event::command::GapInit {
+            service_handle,
+            dev_name_handle,
+            appearance_handle,
+            ..
+        }),
+    ) = return_params
+    {
+        (service_handle, dev_name_handle, appearance_handle)
+    } else {
+        rprintln!("Unexpected response to init_gap command");
+        return Err(());
+    };
+
+    perform_command(|rc| {
+        rc.update_characteristic_value(&UpdateCharacteristicValueParameters {
+            service_handle,
+            characteristic_handle: dev_name_handle,
+            offset: 0,
+            value: BLE_BEACON_NAME,
+        })
+        .map_err(|_| nb::Error::Other(()))
+    })?;
+
+    let appearance_characteristic = Characteristic {
+        service: service_handle,
+        characteristic: appearence_handle,
+        max_len: 4,
+    };
+
+    appearance_characteristic.set_value(&[0x80, 0x00])?;
+    return Ok(());
+}
+
+fn init_ibeacon() -> Result<(), ()> {
+    // disable scan response
+    perform_command(|rc: &mut RadioCopro| {
+        rc.le_set_scan_response_data(&[])
+            .map_err(|_| nb::Error::Other(()))
+    })?;
+
+    // non-connectable mode...
+    perform_command(|rc| {
+        rc.set_discoverable(&DISCOVERY_PARAMS)
+            .map_err(|_| nb::Error::Other(()))
+    })?;
+
+    // remove some advertisements to decrease packet size
+    perform_command(|rc| rc.delete_ad_type(AdvertisingDataType::TxPowerLevel))?;
+    perform_command(|rc| rc.delete_ad_type(AdvertisingDataType::PeripheralConnectionInterval))?;
+
+    perform_command(|rc| {
+        let mut service_data = [0u8; 27];
+        service_data[0] = 26;
+        service_data[1] = AdvertisingDataType::ManufacturerSpecificData as u8;
+
+        // iBeacon specific 32-bit data blob
+        service_data[2] = 0x4C;
+        service_data[3] = 0x00;
+        service_data[4] = 0x02;
+        service_data[5] = 0x15;
+
+        // Uuid bytes
+        let mut index = 6;
+        service_data[index..(index + IBEACON_UUID.len())].copy_from_slice(&IBEACON_UUID[..]);
+        index += IBEACON_UUID.len();
+
+        // Major bytes
+        service_data[index..(index + IBEACON_MAJOR.len())].copy_from_slice(&IBEACON_MAJOR[..]);
+        index += IBEACON_MAJOR.len();
+
+        // Minor bytes
+        service_data[index..(index + IBEACON_MINOR.len())].copy_from_slice(&IBEACON_MAJOR[..]);
+        index += IBEACON_MINOR.len();
+
+        // TX power at 0 meters for ranging
+        service_data[index] = CALIBRATED_TX_POWER_AT_0_M;
+
+        rc.update_advertising_data(&service_data[..])
+            .map_err(|_| nb::Error::Other(()))
+    })?;
+
+    perform_command(|rc| {
+        let mut service_uuid_list = [0u8; 18];
+        service_uuid_list[0] = 17;
+        service_uuid_list[1] = AdvertisingDataType::UuidCompleteList16 as u8;
+        service_uuid_list[2..(2 + IBEACON_UUID.len())].copy_from_slice(&IBEACON_UUID[..]);
+
+        rc.update_advertising_data(&service_uuid_list[..])
+            .map_err(|_| nb::Error::Other(()))
+    })?;
+
+    perform_command(|rc| {
+        let flags = [
+            2,
+            AdvertisingDataType::Flags as u8,
+            (0x02 | 0x04) as u8, // BLE general discoverable, without BR/EDR support.
+        ];
+
+        rc.update_advertising_data(&flags[..])
+            .map_err(|_| nb::Error::Other(()))
+    })?;
+
+    return Ok(());
+}
+
+fn get_random_addr() -> BdAddr {
+    let mut bytes = [0u8; 6];
+
+    let lhci_info = LhciC1DeviceInformationCcrp::new();
+    bytes[0] = (lhci_info.uid64 & 0xff) as u8;
+    bytes[1] = ((lhci_info.uid64 >> 8) & 0xff) as u8;
+    bytes[2] = ((lhci_info.uid64 >> 16) & 0xff) as u8;
+    bytes[3] = 0;
+    bytes[4] = 0x6E;
+    bytes[5] = 0xED;
+
+    BdAddr(bytes)
+}
+
+const BLE_CFG_IRK: [u8; 16] = [
+    0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+];
+const BLE_CFG_ERK: [u8; 16] = [
+    0xfe, 0xdc, 0xba, 0x09, 0x87, 0x65, 0x43, 0x21, 0xfe, 0xdc, 0xba, 0x09, 0x87, 0x65, 0x43, 0x21,
+];
+
+fn get_irk() -> EncryptionKey {
+    EncryptionKey(BLE_CFG_IRK)
+}
+
+fn get_erk() -> EncryptionKey {
+    EncryptionKey(BLE_CFG_ERK)
+}
+
+const DISCOVERY_PARAMS: DiscoverableParameters = DiscoverableParameters {
+    advertising_type: AdvertisingType::NonConnectableUndirected,
+    advertising_interval: Some((
+        Duration::from_millis(ADV_INTERVAL_MS),
+        Duration::from_millis(ADV_INTERVAL_MS),
+    )),
+    address_type: OwnAddressType::Public,
+    filter_policy: AdvertisingFilterPolicy::AllowConnectionAndScan,
+    // Local name should be empty for the device to be recognized as an Eddystone beacon
+    local_name: None,
+    advertising_data: &[],
+    conn_interval: (None, None),
+};

--- a/src/command/gatt.rs
+++ b/src/command/gatt.rs
@@ -1495,6 +1495,10 @@ bitflags! {
     /// characteristics. Defined in Volume 3, Part G, Section 3.3.3.1 of Bluetooth Specification
     /// 4.1.
     pub struct CharacteristicProperty: u8 {
+        /// If no properties are set, this characteristic will be unavailable.
+        /// 0 is defined in ST's AN5270, but _not_ in the BT Core spec!
+        const NONE = 0x0;
+
         /// If set, permits broadcasts of the Characteristic Value using Server Characteristic
         /// Configuration Descriptor. If set, the Server Characteristic Configuration Descriptor
         /// shall exist.
@@ -1540,6 +1544,9 @@ bitflags! {
     /// [Permissions](AddCharacteristicParameter::security_permissions) available for
     /// characteristics.
     pub struct CharacteristicPermission: u8 {
+        /// No permissions assigned, neither authentication nor encryption
+        const NONE = 0x0;
+
         /// Need authentication to read.
         const AUTHENTICATED_READ = 0x01;
 
@@ -1563,6 +1570,9 @@ bitflags! {
 bitflags! {
     /// Which events may be generated when a characteristic is accessed.
     pub struct CharacteristicEvent: u8 {
+        /// No events will be notified for this attribute.
+        const NO_NOTIFY = 0x0;
+
         /// The application will be notified when a client writes to this attribute.
         const ATTRIBUTE_WRITE = 0x01;
 
@@ -1643,7 +1653,7 @@ pub struct AddDescriptorParameters<'a> {
     pub descriptor_value: &'a [u8],
 
     /// What security requirements must be met before the descriptor can be accessed.
-    pub security_permissions: DescriptorPermission,
+    pub security_permissions: CharacteristicPermission,
 
     /// What types of access are allowed for the descriptor.
     pub access_permissions: AccessPermission,
@@ -1720,27 +1730,22 @@ impl From<KnownDescriptor> for Uuid {
 }
 
 bitflags! {
-    /// Permissions available for characteristic descriptors.
-    pub struct DescriptorPermission: u8 {
-        /// Authentication required.
-        const AUTHENTICATED = 0x01;
-
-        /// Authorization required.
-        const AUTHORIZED = 0x02;
-
-        /// Encryption required.
-        const ENCRYPTED = 0x04;
-    }
-}
-
-bitflags! {
     /// Types of access for characteristic descriptors
     pub struct AccessPermission: u8 {
+        /// No permissions required
+        const NONE = 0x0;
+
         /// Readable
         const READ = 0x01;
 
         /// Writable
         const WRITE = 0x02;
+
+        /// Write without response
+        const WRITE_WO_RESP = 0x4;
+
+        /// Signed write
+        const SIGNED_WRITE = 0x8;
 
         /// Readable and writeable
         const READ_WRITE = Self::READ.bits | Self::WRITE.bits;


### PR DESCRIPTION
Based on AN5270rev10

For ACI_GATT_ADD_CHAR, added the "NONE" properties, and the "NO_NOTIFY"
gatt event mask.

For ACI_GATT_ADD_CHAR_DESC, reused the same security bitflags, and
extended the access bitflags.

Signed-off-by: Karl Palsson <karlp@etactica.com>
Fixes: https://github.com/eupn/stm32wb55/issues/5

This might constitute "breaking" as I dropped the old redundant "DescriptorPermission"