### PR TITLE
Update examples as minimally as possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ default = ["ms"]
 ms = []
 
 [dependencies]
-stm32wb-hal = { version = "0.1.1" }
-nb = "0.1.1"
+stm32wb-hal = { version = "0.1.1" , features=["xG-package"]}
+nb = "1.0"
 bluetooth-hci = "0.1"
-bitflags = "1.0"
-bbqueue = "0.4.8"
+bitflags = "1.3"
+bbqueue = "0.4"
 
 [dependencies.embedded-hal]
 version = "0.2.3"
@@ -32,18 +32,16 @@ default-features = false
 
 # For examples
 [dev-dependencies]
-cortex-m = "0.6.2"
+cortex-m = "0.6.7"
 stm32wb-pac = "0.2"
-as-slice = "0.1"
-bit_field = "0.10.0"
-heapless = "0.5.3"
-nb = "0.1"
-cortex-m-rtfm = "0.5"
+as-slice = "0.2"
+bit_field = "0.10"
+heapless = "0.7.5"
+nb = "1.0"
+cortex-m-rtic = "0.5"
 panic-halt = "0.2.0"
 panic-reset = "0.1.0"
-panic-semihosting = "0.5.0"
-cortex-m-semihosting = { version = "0.3.5", features = ["jlink-quirks"] }
-cortex-m-rt = "0.6.6"
+cortex-m-rt = "0.6.7"
 usb-device = "0.2"
 usbd-serial = "0.1.0"
 
@@ -55,3 +53,7 @@ codegen-units = 1
 codegen-units = 1
 debug = true
 lto = true
+
+[patch.crates-io]
+# The Tiwalun demos required this, but we _probably_ don't unless we need those few attributes that were updated
+bluetooth-hci = { git = "https://github.com/danielgallagher0/bluetooth-hci", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["ms"]
 ms = []
 
 [dependencies]
-stm32wb-hal = { version = "0.1.1" , features=["xG-package"]}
+stm32wb-hal = { version = "0.1.14" }
 nb = "1.0"
 bluetooth-hci = "0.1"
 bitflags = "1.3"
@@ -32,6 +32,8 @@ default-features = false
 
 # For examples
 [dev-dependencies]
+# Need explicit features here
+stm32wb-hal = { version = "0.1.14" , features=["xG-package", "stm32-usbd"]}
 cortex-m = "0.6.7"
 stm32wb-pac = "0.2"
 as-slice = "0.2"
@@ -40,7 +42,6 @@ heapless = "0.7.5"
 nb = "1.0"
 cortex-m-rtic = "0.5"
 panic-halt = "0.2.0"
-panic-reset = "0.1.0"
 cortex-m-rt = "0.6.7"
 usb-device = "0.2"
 usbd-serial = "0.1.0"

--- a/examples/transparent_mode.rs
+++ b/examples/transparent_mode.rs
@@ -3,12 +3,12 @@
 #![no_std]
 #![allow(non_snake_case)]
 
-extern crate panic_semihosting;
-extern crate stm32wb_hal as hal;
+use panic_halt as _;
+use stm32wb_hal as hal;
 
 use cortex_m_rt::exception;
 
-use rtfm::app;
+use rtic::app;
 
 use hal::flash::FlashExt;
 use hal::prelude::*;
@@ -233,14 +233,14 @@ const APP: () = {
         if let Ok(cmd) = cmd {
             match &cmd {
                 TlPacketType::AclData => {
-                    cortex_m_semihosting::hprintln!("Got ACL DATA cmd").unwrap();
+                    //cortex_m_semihosting::hprintln!("Got ACL DATA cmd").unwrap();
 
                     // Destination buffer: ble table, phci_acl_data_buffer, acldataserial field
                     todo!()
                 }
 
                 TlPacketType::SysCmd => {
-                    cortex_m_semihosting::hprintln!("Got SYS cmd").unwrap();
+                    //cortex_m_semihosting::hprintln!("Got SYS cmd").unwrap();
 
                     // Destination buffer: SYS table, pcmdbuffer, cmdserial field
                     todo!()
@@ -261,7 +261,7 @@ const APP: () = {
                 }
             }
         } else {
-            cortex_m_semihosting::hprintln!("Got unknown cmd 0x{:02x}", cmd_code).unwrap();
+            //cortex_m_semihosting::hprintln!("Got unknown cmd 0x{:02x}", cmd_code).unwrap();
         }
     }
 


### PR DESCRIPTION
This updates the eddystone/ibeacon examples to the new APIs, with out making any _extra_ changes to halt mechanisms, or program structure.

Tested on a Nucleo WB55 board.